### PR TITLE
Merge

### DIFF
--- a/vla/src/crane_x7_vla/backends/pi0/models_pytorch/gemma_pytorch.py
+++ b/vla/src/crane_x7_vla/backends/pi0/models_pytorch/gemma_pytorch.py
@@ -8,10 +8,11 @@ from typing import Literal
 
 import torch
 from torch import nn
-from transformers import GemmaForCausalLM, PaliGemmaForConditionalGeneration
+from transformers import PaliGemmaForConditionalGeneration
 from transformers.cache_utils import Cache
 from transformers.models.auto import CONFIG_MAPPING
 from transformers.models.gemma import modeling_gemma
+from transformers.models.gemma.modeling_gemma import GemmaForCausalLM
 
 
 class PaliGemmaWithExpertModel(nn.Module):


### PR DESCRIPTION
transformersモジュールから直接インポートするのではなく、
transformers.models.gemma.modeling_gemmaからインポートするよう変更。 modeling_gemmaモジュールとの整合性を確保するための修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)